### PR TITLE
Fixed example config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,26 @@ grunt.initConfig({
 	// ...
 
 	sketch_export: {
-		options: {
-			type: 'slices',
-			items: [
-				'Grunt Logo',
-				'Symbol',
-				'Text'
-			],
-			scales: [
-				1.0,
-				2.0
-			],
-			formats: [
-				'png',
-				'jpg'
-			]
-		},
-		src: 'src/sketch/Grunt Logo.sketch',
-		dest: 'build/assets'
+		gruntLogo: {
+			options: {
+				type: 'slices',
+				items: [
+					'Grunt Logo',
+					'Symbol',
+					'Text'
+				],
+				scales: [
+					1.0,
+					2.0
+				],
+				formats: [
+					'png',
+					'jpg'
+				]
+			},
+			src: 'src/sketch/Grunt Logo.sketch',
+			dest: 'build/assets'
+		}
 	},
 
 	// ...


### PR DESCRIPTION
sketch_export config needs each set of [options, src, dest] to be wrapped in a task object, otherwise 'src' and 'dest' get run as separate tasks. While this is fine in the code, the README is incorrect, so after spending a while going through the code to work out what was going wrong, I've decided to change the README to make it easier for users of the plugin.