### PR TITLE
Move fatal check for sketchtool to task execution rather than on load

### DIFF
--- a/tasks/sketch.js
+++ b/tasks/sketch.js
@@ -118,22 +118,41 @@ module.exports = function ( grunt ) {
 		}
 	];
 
+	// Ensure SketchTool is installed and available in the path.
+
+	function ensureSketchtool() {
+		try {
+			which.sync( bin );
+		} catch ( err ) {
+			grunt.warn(
+				'\nSketchTool must be installed and in your PATH for this task to work.\n' +
+				'Please see: https://github.com/CodeCatalyst/grunt-sketch\n'
+			);
+			return false;
+		}
+		return true;
+	}
+
 	// Internal helper functions.
 
 	function registerTask( task ) {
 		grunt.registerMultiTask( task.name, task.help, function () {
 			var done = this.async();
-			var options = this.options();
+			if(ensureSketchtool()) {
+				var options = this.options();
 
-			async.eachLimit( this.files, numCPUs, function ( file, next ) {
-				var command = createCommand( task, file, options );
-				if ( command ) {
-					executeCommand( command, next );
-				}
-				else {
-					next();
-				}
-			}, done );
+				async.eachLimit( this.files, numCPUs, function ( file, next ) {
+					var command = createCommand( task, file, options );
+					if ( command ) {
+						executeCommand( command, next );
+					}
+					else {
+						next();
+					}
+				}, done );
+			} else {
+				done(false);
+			}
 		} );
 	}
 
@@ -230,17 +249,6 @@ module.exports = function ( grunt ) {
 			}
 			next();
 		} );
-	}
-
-	// Ensure SketchTool is installed and available in the path.
-
-	try {
-		which.sync( bin );
-	} catch ( err ) {
-		return grunt.warn(
-			'\nSketchTool must be installed and in your PATH for this task to work.\n' +
-			'Please see: https://github.com/CodeCatalyst/grunt-sketch\n'
-		);
 	}
 
 	// Register the tasks declared above.


### PR DESCRIPTION
Many times, you don't care if `sketchtool` is available or not when running _other_ grunt tasks (example: CI test run). In its current state, this task package checks for the bin on load of the package rather than on execution of a task. This patch allows the package to be loaded without a failure, but fail if `sketchtool` is unavailable when a task is run.